### PR TITLE
docs: production-ready documentation and ADR foundation

### DIFF
--- a/docs/specs/01-architecture.md
+++ b/docs/specs/01-architecture.md
@@ -38,7 +38,7 @@ flowchart LR
     M2[Sync Agent]
     M3[Licensing Service]
     M4[Update Service (electron-updater)]
-    M5[Export/Import Service]
+    M5[Export/Import Service (printToPDF, CSV, DXF adapter)]
     M6[Telemetry Broker]
   end
 
@@ -99,7 +99,7 @@ Licensing (Main)
 
 Update Service (Main)
 
-- Responsibilities: channels, download/apply, signature verification, rollback strategy
+- Responsibilities: channels, download/apply, signature verification, rollback strategy (allowDowngrade)
 - Interfaces: UpdateService
 
 Telemetry Broker (Main)

--- a/docs/specs/03-sizewise-file-format.md
+++ b/docs/specs/03-sizewise-file-format.md
@@ -1,10 +1,12 @@
-# .sizewise File Format (Draft v0.1)
+# .sizewise File Format (Draft v0.2)
 
 Goals: deterministic round-trip, versioned, integrity-protected, optionally encrypted.
 
 ## Container
-- Format: JSON document (UTF-8)
-- Top-level fields:
+
+- Format: JSON document (UTF-8) or ZIP container when embedding assets
+- MIME type: application/vnd.sizewise+json (JSON) or application/vnd.sizewise+zip (ZIP)
+- Top-level fields (JSON profile):
 ```json
 {
   "format": "sizewise",
@@ -13,7 +15,7 @@ Goals: deterministic round-trip, versioned, integrity-protected, optionally encr
   "appVersion": "1.0.0",
   "project": { /* see schema */ },
   "entities": { /* jobs, segments, endpoints, locations, results */ },
-  "meta": { "units": "imperial|metric" },
+  "meta": { "units": "imperial|metric", "publicKeyHint": "optional" },
   "integrity": {
     "algo": "SHA-256",
     "hash": "<hex>",
@@ -28,6 +30,8 @@ Goals: deterministic round-trip, versioned, integrity-protected, optionally encr
 }
 ```
 
+- ZIP profile: place the above JSON at /manifest.json; include assets under /assets/**; integrity & signing apply to canonicalized manifest bytes.
+
 ## Entities (normalized)
 - project: { id, name, unitSystem, createdAt, updatedAt, notes }
 - jobs: [ { id, projectId, title, altitudeFt, preferredVelocityFpm, roomType, defaultLocationId } ]
@@ -36,13 +40,17 @@ Goals: deterministic round-trip, versioned, integrity-protected, optionally encr
 - locations: [ { id, projectId, building, level, roomCode, roomName, locationType, tags } ]
 - results: [ { id, segmentId, velocityFpm, reynolds, frictionPer100ft, fittingsLoss, totalLoss, warnings, computedAt } ]
 
-## Integrity
-- Compute SHA-256 over the JSON canonical form excluding `integrity` and `encryption` objects.
-- Optional signing: detached signature over the same bytes; include public key hint in meta when signed.
+## Integrity & Signing
+
+- Compute SHA-256 over the canonical JSON excluding `integrity` and `encryption` objects.
+- Optional detached signature (ed25519 or RSA) over the same bytes; include a public key hint in meta when signed.
+- Strict mode: refuse unsigned imports; Standard mode: allow unsigned with warning; Labs mode: allow bypass for testing only.
 
 ## Encryption (optional)
+
 - AES-256-GCM with per-export random IV.
 - Key derived from user passphrase via Argon2id; store salt and parameters in `encryption.kdf`.
+- Password policy: min length 12, rate-limit decrypt attempts (e.g., 5 tries then exponential backoff)
 - When encrypted, JSON payload becomes a compact binary blob encoded in base64 under `payload`, and most top-level fields move into an unencrypted header: { format, version, createdAt, appVersion, meta, encryption, integrity }.
 
 ## Versioning & Migration

--- a/docs/specs/06-deployment-playbook.md
+++ b/docs/specs/06-deployment-playbook.md
@@ -26,19 +26,19 @@ Target: Electron (desktop). Channels: stable, beta. Provider: GitHub Releases or
 - Use electron-updater in Main: check on start (deferred), allow manual check; download in background; prompt before apply.
 
 ## Signing & Notarization
-- Store cert refs in CI secrets; never commit private keys.
-- macOS: sign with Developer ID, upload for notarization, staple ticket.
-- Windows: sign with EV cert; timestamping server.
+- Store cert refs in CI secrets; never commit private keys. Prefer OIDC and keychain on self-hosted runners where possible.
+- macOS: sign with Developer ID; notarize with notarytool; staple ticket; document Gatekeeper/App Translocation behavior.
+- Windows: RFC3161 timestamping (e.g., http://timestamp.digicert.com); EV cert optional but recommended to build SmartScreen reputation.
 
 ## CI/CD (GitHub Actions sketch)
 - Jobs: lint/test → build per OS → sign/notarize → publish release → upload artifacts → create release notes
 - Use matrix builds; protect main; require passing checks
 
 ## Channels & Versioning
-- Semantic versioning. Beta channel for pre-release tags. AutoUpdater feeds by channel.
+- Semantic versioning (Conventional Commits drive release notes). Beta channel for pre-release tags. AutoUpdater feeds by channel.
 
 ## Rollback Strategy
-- Keep last 2 versions cached; allow user-triggered rollback.
+- Keep last 2 versions cached; allow user-triggered rollback. Updater allowDowngrade: true; flip channel pointer to prior stable tag for mass rollback.
 
 ## Release Notes
 - Generated from conventional commits; include breaking changes section.

--- a/docs/specs/07-security-requirements.md
+++ b/docs/specs/07-security-requirements.md
@@ -12,15 +12,16 @@ Scope: Desktop-only (Electron). No smartphones. Tablets only if running desktop 
 - At-rest protection
   - Encrypt sensitive data (either full DB or selected tables/fields)
   - Keys stored via OS keystores: Keychain (macOS), DPAPI (Windows), libsecret (Linux) using keytar
-  - Lockdown export encryption (AES‑256‑GCM) with Argon2id KDF when user sets a passphrase
+  - Lockdown export encryption (AES‑256‑GCM) with Argon2id KDF when user sets a passphrase (min length 12; rate-limit decrypt attempts)
 - Update integrity
   - Use signed installers and signed auto-updates (electron-updater); reject unsigned artifacts
   - HTTPS/TLS 1.2+ to update provider; optional certificate pinning
 - Integrity & signing for .sizewise
   - SHA‑256 over canonical JSON; optional detached signature (public key hint in meta)
+  - Import policy modes: Strict (signed only), Standard (unsigned allowed with warning), Labs (testing only)
 - Logs & telemetry
   - Sanitize logs; never serialize full project payloads in error logs
-  - Telemetry/crash reporting is opt-in; no PII; redact IDs when possible
+  - Telemetry/crash reporting is opt-in (default off); no PII; redact IDs; rotate telemetry keys
 - IPC hardening
   - contextIsolation: true; nodeIntegration: false; preload exposes minimal, typed APIs
   - Validate all inputs server-side (Main) before DB writes

--- a/docs/specs/09-licensing-tier-spec.md
+++ b/docs/specs/09-licensing-tier-spec.md
@@ -15,10 +15,7 @@
 ## Enforcement Points
 - At UI action dispatch; at DataService level as last resort
 - Hard blocks for over-limit creates; soft warnings near thresholds
-- Grace Mode (default 7 days):
-  - Editing allowed; exports allowed but watermarked (PDF/DXF/CSV)
-  - Cloud sync (if present) disabled; batch exports disabled
-  - Audit event recorded (lic_grace_entered) with anonymized fingerprint
+- Grace Mode (7 days): exports allowed but watermarked (PDF/DXF/CSV), cloud sync disabled, batch exports disabled; audit event recorded
 
 ## Storage & Security
 - Store license blob and verification status; cache in DB; keep original file

--- a/docs/specs/09-licensing-tier-spec.md
+++ b/docs/specs/09-licensing-tier-spec.md
@@ -15,6 +15,10 @@
 ## Enforcement Points
 - At UI action dispatch; at DataService level as last resort
 - Hard blocks for over-limit creates; soft warnings near thresholds
+- Grace Mode (default 7 days):
+  - Editing allowed; exports allowed but watermarked (PDF/DXF/CSV)
+  - Cloud sync (if present) disabled; batch exports disabled
+  - Audit event recorded (lic_grace_entered) with anonymized fingerprint
 
 ## Storage & Security
 - Store license blob and verification status; cache in DB; keep original file

--- a/docs/specs/10-exporters-spec.md
+++ b/docs/specs/10-exporters-spec.md
@@ -1,37 +1,43 @@
 # Exporters Spec (PDF, CSV, DXF) (Draft v0.2)
 
 ## Libraries & Rendering Paths
+
 - PDF (primary): Electron webContents.printToPDF via hidden/offscreen BrowserWindow
 - PDF (fallback): pdf-lib for data-only composition (no HTML rendering)
 - CSV: native CSV stringify (UTF‑8, RFC 4180-ish)
 - DXF: dxf-writer v4.x (or @tarikjabiri/dxf) behind an adapter
 
 ## PDF via Electron
+
 - Create a hidden BrowserWindow to load an HTML report template
 - Embed fonts with @font-face; inline CSS for determinism
 - Use printToPDF options for page size, margins, background graphics
 - Include app version, ruleset hash, and export timestamp in footer
 
 ## CSV Mapping
+
 - segments.csv: inputs (ids, geometry, airflow, material, fittings, endpoints, locations)
 - results.csv: computed outputs (velocity, Reynolds, friction/100ft, fittings loss, total loss, pressure class)
 - endpoints.csv, locations.csv as reference tables
 - Deterministic ordering: job → order_index → id
 
 ## DXF Conventions
+
 - DXF version: R2018
 - Units: inches (INSUNITS=1)
 - Layers: DUCT_MAIN, FITTINGS, LABELS, NODES, GUIDES
-- Text style: SIZEWISE_STD (height 0.125 in), font Arial or embedded SHX
+- Text style: SIZEWISE_STD (height 0.125 in), font Arial or embedded SHX (fallback)
 - Colors: fixed index map per layer; document in adapter
 - Blocks: define fittings (elbows, tees) with consistent insertion points
 - Performance: support up to ~100k entities; chunk writes to avoid memory spikes
 
 ## Errors & Recovery
+
 - Missing fonts/images → fallback to defaults with warning
 - Invalid geometry → skip entity and log warning
 - DXF write failure → abort file and emit actionable error; never produce partial corrupt files
 
 ## Versioning & Provenance
+
 - Include app version & ruleset hash in PDF footer and CSV headers; DXF header comment
 - Record exporter version (adapter version) in file metadata where applicable

--- a/docs/specs/10-exporters-spec.md
+++ b/docs/specs/10-exporters-spec.md
@@ -1,22 +1,37 @@
-# Exporters Spec (PDF, CSV, DXF) (Draft v0.1)
+# Exporters Spec (PDF, CSV, DXF) (Draft v0.2)
 
-## Libraries (proposal)
-- PDF: pdf-lib (offline, no headless dependency)
+## Libraries & Rendering Paths
+- PDF (primary): Electron webContents.printToPDF via hidden/offscreen BrowserWindow
+- PDF (fallback): pdf-lib for data-only composition (no HTML rendering)
 - CSV: native CSV stringify (UTF‑8, RFC 4180-ish)
-- DXF: dxf-writer or @tarikjabiri/dxf (start with basic entities)
+- DXF: dxf-writer v4.x (or @tarikjabiri/dxf) behind an adapter
 
-## Data Mapping
-- PDF: cover page (project/job meta), results tables (segments), warnings list, optional logo
-- CSV: segments.csv (inputs), results.csv (computed outputs), endpoints.csv, locations.csv
-- DXF: simplified plan—nodes as blocks, ducts as polylines with width labels; scale annotations
+## PDF via Electron
+- Create a hidden BrowserWindow to load an HTML report template
+- Embed fonts with @font-face; inline CSS for determinism
+- Use printToPDF options for page size, margins, background graphics
+- Include app version, ruleset hash, and export timestamp in footer
 
-## Determinism & Units
-- Lock unit system per export; include unit headers; stable ordering by job → order_index → id
+## CSV Mapping
+- segments.csv: inputs (ids, geometry, airflow, material, fittings, endpoints, locations)
+- results.csv: computed outputs (velocity, Reynolds, friction/100ft, fittings loss, total loss, pressure class)
+- endpoints.csv, locations.csv as reference tables
+- Deterministic ordering: job → order_index → id
+
+## DXF Conventions
+- DXF version: R2018
+- Units: inches (INSUNITS=1)
+- Layers: DUCT_MAIN, FITTINGS, LABELS, NODES, GUIDES
+- Text style: SIZEWISE_STD (height 0.125 in), font Arial or embedded SHX
+- Colors: fixed index map per layer; document in adapter
+- Blocks: define fittings (elbows, tees) with consistent insertion points
+- Performance: support up to ~100k entities; chunk writes to avoid memory spikes
 
 ## Errors & Recovery
 - Missing fonts/images → fallback to defaults with warning
 - Invalid geometry → skip entity and log warning
+- DXF write failure → abort file and emit actionable error; never produce partial corrupt files
 
-## Versioning
+## Versioning & Provenance
 - Include app version & ruleset hash in PDF footer and CSV headers; DXF header comment
-
+- Record exporter version (adapter version) in file metadata where applicable

--- a/docs/specs/11-testing-strategy.md
+++ b/docs/specs/11-testing-strategy.md
@@ -1,4 +1,4 @@
-# Testing Strategy (Draft v0.1)
+# Testing Strategy (Draft v0.2)
 
 ## Scope
 - Unit: calc engine (goldens + property-based), validators, licensing, helpers
@@ -26,4 +26,19 @@
 - Calc recompute for segment < 200ms typical
 - Canvas panning ~60 FPS on mid-tier hardware
 - Cold start < 2s; steady-state memory < 1.5 GB on large projects
+
+## Performance Measurement Protocol
+- Baseline hardware: one of
+  - Intel i5-11400 (6C/12T), 16 GB RAM, NVMe SSD; Windows 11
+  - Apple M1 (8C), 16 GB RAM; macOS 13+
+- Method:
+  - Warm-up: run each scenario 3 times; measure next 10; report P95
+  - Disable background sync/updates; ensure consistent Node/Electron versions
+  - Record environment in output (OS, CPU, RAM, Electron/Node versions)
+- Datasets:
+  - Small (≤300 segments), Medium (≤2,000), Large (≤10,000)
+- Targets:
+  - Bulk recompute: ≤2.5s (Medium, P95), ≤12s (Large, P95)
+  - Canvas panning: ≥55 FPS steady on Large
+  - Memory caps: ≤300MB (Small), ≤900MB (Medium), ≤1.5GB (Large)
 

--- a/docs/specs/11-testing-strategy.md
+++ b/docs/specs/11-testing-strategy.md
@@ -1,4 +1,4 @@
-# Testing Strategy (Draft v0.2)
+# Testing Strategy (Draft v0.1)
 
 ## Scope
 - Unit: calc engine (goldens + property-based), validators, licensing, helpers
@@ -15,6 +15,11 @@
 - 10+ canonical segments/jobs with expected numeric outputs and warnings
 - Lock rounding order and constants; fail fast on drift
 
+## Fuzz & Invariants
+- Fuzz import manifests with random omissions/extra keys → assert graceful failures (no crashes)
+- Invariants: pressure loss ≥ 0; Reynolds ≥ 0; Q ≈ V·A within tolerance; unit conversions roundtrip within tolerance
+- Cross-platform: file paths/line endings/locale differences don’t affect results
+
 ## Offline/Online Scenarios
 - Simulate network loss; ensure queue persists; verify UI badges and retries (if sync)
 
@@ -26,19 +31,4 @@
 - Calc recompute for segment < 200ms typical
 - Canvas panning ~60 FPS on mid-tier hardware
 - Cold start < 2s; steady-state memory < 1.5 GB on large projects
-
-## Performance Measurement Protocol
-- Baseline hardware: one of
-  - Intel i5-11400 (6C/12T), 16 GB RAM, NVMe SSD; Windows 11
-  - Apple M1 (8C), 16 GB RAM; macOS 13+
-- Method:
-  - Warm-up: run each scenario 3 times; measure next 10; report P95
-  - Disable background sync/updates; ensure consistent Node/Electron versions
-  - Record environment in output (OS, CPU, RAM, Electron/Node versions)
-- Datasets:
-  - Small (≤300 segments), Medium (≤2,000), Large (≤10,000)
-- Targets:
-  - Bulk recompute: ≤2.5s (Medium, P95), ≤12s (Large, P95)
-  - Canvas panning: ≥55 FPS steady on Large
-  - Memory caps: ≤300MB (Small), ≤900MB (Medium), ≤1.5GB (Large)
 

--- a/docs/specs/18-ci-cd-skeleton.md
+++ b/docs/specs/18-ci-cd-skeleton.md
@@ -14,11 +14,15 @@
   - on: tag push (vX.Y.Z or vX.Y.Z-beta.N)
   - jobs: build-sign-notarize → publish (GitHub Releases) → create release notes
 
+## Provider (Updates)
+- GitHub Releases (default provider for electron-updater)
+
 ## Secrets Required
 - WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD (Windows signing)
 - CSC_LINK / CSC_KEY_PASSWORD (macOS Developer ID)
-- GH_TOKEN for GitHub Releases
+- GH_TOKEN for GitHub Releases (no echo)
 
-## Provenance
+## Security & Provenance
+- Prefer OIDC and short-lived tokens; avoid storing certs in plaintext in CI
 - Consider SLSA/GitHub OIDC attestation for build provenance
 

--- a/docs/specs/42-release-operations-guide.md
+++ b/docs/specs/42-release-operations-guide.md
@@ -1,12 +1,13 @@
 # Release Operations Guide (Documents Only)
 
 ## Steps
-1. Cut release branch; bump version
-2. Build and sign per OS; notarize macOS
-3. Publish to chosen provider; attach release notes and checksums
-4. Promote beta → stable if no blocking issues
-5. Monitor crash/perf metrics (opt-in) and support tickets
-6. Rollback if needed using cached previous installer
+1. Freeze window: no non-critical merges 48 hours before planned release
+2. Cut release branch; bump version
+3. Build and sign per OS; notarize macOS; staple tickets
+4. Publish to GitHub Releases; attach release notes and checksums
+5. Smoke test on each OS; then promote beta → stable if no blocking issues
+6. Monitor crash/perf metrics (opt-in) and support tickets
+7. Rollback if needed using cached previous installer and allowDowngrade policy
 
 ## Templates
 - Release notes sections: Features, Fixes, Breaking Changes, Known Issues

--- a/docs/specs/45-adr-index.md
+++ b/docs/specs/45-adr-index.md
@@ -3,20 +3,13 @@
 Document key decisions and their rationale. Create one ADR per decision.
 
 ## Accepted ADRs
+- ADR-0001 Platform Stack (Desktop-Only)
+- ADR-0002 UI Model (Canvas-First Canonical Intake)
+- ADR-0003 Export Policy (Security & Allowlist)
+- ADR-0004 Canvas Scope (MVP)
 - ADR-0005 SizeWise Packaging (.sizewise JSON/ZIP)
 - ADR-0006 DXF Profile & Fonts (R2018, inches, Arial with SHX fallback)
 - ADR-0007 Update Provider (GitHub Releases)
 - ADR-0008 Grace Mode Policy (7 days, watermark, sync/batch restrictions)
 - ADR-0009 Labor Cost Enablement (post-MVP, placeholder)
-
-## Proposed ADRs
-- ADR-001 Desktop-only scope; no smartphones; Electron primary
-- ADR-002 Database engine: SQLite via better-sqlite3; WAL; migrations strategy
-- ADR-003 Update mechanism: electron-updater with provider (GitHub Releases/S3)
-- ADR-004 File format: .sizewise JSON with integrity+optional signing/encryption
-- ADR-005 Security posture: encryption-at-rest (scope), OS keystore for keys, opt-in telemetry
-- ADR-006 Calculation engine: deterministic pure functions + ruleset JSON
-- ADR-007 Exporters: pdf-lib + dxf-writer initial scope
-- ADR-008 Licensing: signed JSON license blob; offline verification; tier gates
-- ADR-009 Sync MVP: decision and approach (in or out)
 

--- a/docs/specs/45-adr-index.md
+++ b/docs/specs/45-adr-index.md
@@ -2,6 +2,13 @@
 
 Document key decisions and their rationale. Create one ADR per decision.
 
+## Accepted ADRs
+- ADR-0005 SizeWise Packaging (.sizewise JSON/ZIP)
+- ADR-0006 DXF Profile & Fonts (R2018, inches, Arial with SHX fallback)
+- ADR-0007 Update Provider (GitHub Releases)
+- ADR-0008 Grace Mode Policy (7 days, watermark, sync/batch restrictions)
+- ADR-0009 Labor Cost Enablement (post-MVP, placeholder)
+
 ## Proposed ADRs
 - ADR-001 Desktop-only scope; no smartphones; Electron primary
 - ADR-002 Database engine: SQLite via better-sqlite3; WAL; migrations strategy

--- a/docs/specs/47-db-corruption-runbook.md
+++ b/docs/specs/47-db-corruption-runbook.md
@@ -1,0 +1,28 @@
+# Runbook: Database Corruption & Recovery (Documents Only)
+
+## Detection
+- Startup health check: PRAGMA quick_check; if fails, PRAGMA integrity_check
+- Watcher: unexpected SQLITE_CORRUPT/SQLITE_IOERR/SQLITE_NOTADB errors during ops
+
+## Preflight
+- Before repair attempts, create read-only snapshot copy of DB file with timestamp
+- Record event in logs (correlationId)
+
+## Recovery Flow (in order)
+1) Safe snapshot → export .sizewise.recovery (best effort); inform user
+2) Auto-backup restore → load last good WAL snapshot from appData/backups/auto/
+3) Rebuild → VACUUM INTO new file; re-apply migrations; rebuild indices; verify quick_check
+4) User prompt → if still failing, offer: Open recovery, Restore snapshot…, Contact support
+
+## Give-up Threshold
+- After 3 failed repairs within 10 minutes, stop auto-retries; block with guidance and support link
+
+## Retention Policy
+- Automatic backups: daily; keep last 7
+- Recovery exports: keep last 3; older are pruned
+
+## Messaging
+- Title: “Project database looks damaged”
+- Body: “We attempted automatic repair. Your latest changes may be in a recovery file.”
+- Actions: “Open recovery”, “Restore snapshot…”, “Contact support”
+

--- a/docs/specs/48-qa-test-case-inventory.md
+++ b/docs/specs/48-qa-test-case-inventory.md
@@ -1,0 +1,41 @@
+# QA Test Case Inventory (Documents Only)
+
+Tagging: [Unit], [Integration], [E2E], [Perf]
+
+## Project & Jobs
+- [E2E] Create/Open/Rename/Delete projects; recent files
+- [Integration] Template apply → fields populated
+- [E2E] Unit system switch preserves values via conversions
+
+## Segments & Calculations
+- [Unit] Velocity/Reynolds/friction calculations on goldens (≥ 20 cases)
+- [Unit] Unit conversion roundtrip idempotence within tolerance
+- [Integration] Invalid inputs surface E_INPUT_VALIDATION with field highlights
+- [Perf] Debounced edits hit SLA (Small ≤ 50ms P95)
+
+## Locations & Endpoints
+- [Integration] CRUD; endpoints linked to segments; breadcrumbs shown
+
+## Import/Export
+- [Integration] Export → import roundtrip equals manifest (canonicalized)
+- [Unit] Integrity/signature checks (strict/standard/labs modes)
+- [Integration] Encrypted export → decrypt with retry/backoff policy
+
+## DXF/PDF/CSV
+- [Integration] PDF footers include app + ruleset hash; fonts rendered
+- [Integration] DXF layers/styles/units correct; entity count up to 100k
+- [Integration] CSV column order stable; units correct
+
+## Licensing
+- [E2E] Grace Mode watermark on exports; sync disabled; audit event logged
+
+## Resilience
+- [E2E] Corrupt DB → runbook flow; restore snapshot
+- [Integration] Backups rotate; give-up threshold blocks repeated repairs
+
+## Updates
+- [E2E] Beta → stable auto-update; rollback path works
+
+## Cross-platform
+- [E2E] Installers run; app launches; file paths and line endings OK on Win/macOS/Linux
+

--- a/docs/specs/49-dxf-layer-style-map.md
+++ b/docs/specs/49-dxf-layer-style-map.md
@@ -19,6 +19,7 @@
 - Font: Arial (fallback SHX if unavailable)
 - Height: 0.125 in (change via config if needed)
 - Color: layer color
+- Encoding: ensure ASCII subset for SHX fallback; avoid glyphs not supported by target CAD
 
 ## Blocks (Fittings)
 - Names: ELBOW_90_LR, ELBOW_45, TEE, TRANSITION

--- a/docs/specs/49-dxf-layer-style-map.md
+++ b/docs/specs/49-dxf-layer-style-map.md
@@ -1,0 +1,39 @@
+# DXF Layer & Style Map (Documents Only)
+
+## DXF Profile
+- Version: R2018
+- Units: inches (INSUNITS=1)
+- UCS: World; origin (0,0,0); scale annotations consistent with inches
+
+## Layers
+| Layer        | Color | Linetype | Purpose                        |
+|--------------|-------|----------|--------------------------------|
+| DUCT_MAIN    | 7     | CONTINUOUS | Main duct polylines            |
+| FITTINGS     | 3     | CONTINUOUS | Elbows, tees, transitions      |
+| LABELS       | 2     | CONTINUOUS | Text labels (sizes, CFM)       |
+| NODES        | 1     | CONTINUOUS | Node markers (equipment/ends)  |
+| GUIDES       | 8     | DASHED     | Construction/snap guides       |
+
+## Text Style
+- Style name: SIZEWISE_STD
+- Font: Arial (fallback SHX if unavailable)
+- Height: 0.125 in (change via config if needed)
+- Color: layer color
+
+## Blocks (Fittings)
+- Names: ELBOW_90_LR, ELBOW_45, TEE, TRANSITION
+- Insertion point: centerline intersection
+- Scaling: uniform; rotation aligns with duct direction
+
+## Conventions
+- Label format: "<width>x<height> @ <CFM>" for rect; "Ø<diam> @ <CFM>" for round
+- Precision: dimensions 0.1 in; CFM as integer
+- Ordering: write nodes → ducts → fittings → labels for deterministic output
+
+## Performance
+- Target: up to ~100k entities
+- Chunk writes to avoid memory spikes; flush after each 5k entities
+
+## Metadata
+- Header comments include app version, ruleset hash, and exporter adapter version
+

--- a/docs/specs/50-performance-harness.md
+++ b/docs/specs/50-performance-harness.md
@@ -1,0 +1,23 @@
+# Performance Harness (Documents Only)
+
+## Datasets
+- Small: ≤300 segments
+- Medium: ≤2,000 segments
+- Large: ≤10,000 segments
+
+## Measurements
+- Input→result latency (P95) after 3 warmups and 10 measured edits
+- Bulk recompute time (P95)
+- Canvas FPS steady-state
+- Memory (RSS) after bulk recompute
+
+## Protocol
+- Baseline hardware: i5-11400/16GB/NVMe (Win11) or Apple M1/16GB (macOS13+)
+- Disable background sync/updates; fix Electron/Node versions
+- Log OS/CPU/RAM and app versions in output
+
+## Acceptance
+- Medium bulk recompute ≤2.5s (P95), Large ≤12s (P95)
+- Canvas panning ≥55 FPS steady on Large
+- Memory caps: ≤300MB (Small), ≤900MB (Medium), ≤1.5GB (Large)
+

--- a/docs/specs/51-ruleset-governance.md
+++ b/docs/specs/51-ruleset-governance.md
@@ -1,0 +1,21 @@
+# Ruleset Governance (Documents Only)
+
+## Versioning
+- Semantic versioning for ruleset (e.g., 1.0.0)
+- Compatibility matrix recorded with app versions
+- Default/kill-switch: default_ruleset_version the app reverts to on verification failure
+
+## Compatibility Example
+- App 1.x supports Ruleset ^1
+- App 2.x supports Ruleset ^2 and ^1 in compatibility mode
+
+## Rollback SOP
+- On ruleset verification failure, revert to default_ruleset_version
+- Raise a telemetry event (opt-in) and show banner explaining downgrade
+- Add incident entry to known issues
+
+## Review Checklist
+- Each constant carries source citation and conditions
+- Tolerances recorded (± acceptable for tests)
+- Diff from prior version captured in changelog notes
+

--- a/docs/specs/adrs/ADR-0001-platform-stack.md
+++ b/docs/specs/adrs/ADR-0001-platform-stack.md
@@ -1,0 +1,29 @@
+# ADR-0001 — Platform Stack (Desktop-Only)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Choose a delivery platform and app stack optimized for offline-first desktop usage with reliable updates and OS integration.
+
+## Decision
+- The application MUST be desktop-only (Windows/macOS/Linux). Smartphones and mobile app stores are out of scope.
+- The platform MUST be Electron (Chromium + Node) with a multi-process model (Main, Renderer, Worker Threads).
+- The UI framework MUST be React; state management SHOULD use Zustand (or equivalent) with predictable selectors.
+- The DB engine MUST be SQLite via better-sqlite3 in the Main process; journal mode WAL.
+- IPC MUST use contextIsolation with a typed contextBridge API; no Node in the renderer.
+
+## Consequences
+### Positive
+- Consistent desktop behavior and stable OS-level features
+- Offline-first flows with fast local DB and predictable updates
+
+### Negative
+- Larger binaries than native frameworks
+- Requires careful IPC contracts and security configuration
+
+## Implementation Requirements
+- Enforce desktop-only language and remove mobile/touch gestures from docs and UI
+- Preload exposes a minimal, typed API surface; all inputs validated in Main
+- DB migrations and WAL mode enforced on startup
+

--- a/docs/specs/adrs/ADR-0002-ui-model-canvas-first.md
+++ b/docs/specs/adrs/ADR-0002-ui-model-canvas-first.md
@@ -1,0 +1,27 @@
+# ADR-0002 — UI Model (Canvas-First Canonical Intake)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Define the primary user interaction model for building duct systems while keeping forms synchronized and secondary.
+
+## Decision
+- Canvas-based intake MUST be the canonical source of truth for creating and editing segments.
+- Forms MUST be synchronized secondary views reflecting canvas selections and model state.
+- Canvas scope for MVP is orthogonal geometry (0°/90°; optional 45° via elbows only); no freehand, no arbitrary angles, no 3D.
+
+## Consequences
+### Positive
+- Intuitive spatial editing aligned with HVAC workflows
+- Reduced chance of model desync between views
+
+### Negative
+- Requires careful hit-testing, selection, and snapping logic
+- Additional work for accessibility and keyboard-driven alternatives
+
+## Implementation Requirements
+- State machine for selection/edit/merge/split/resize flows
+- Deterministic mapping from canvas actions to data mutations
+- Forms auto-populate and validate against the same rules as canvas actions
+

--- a/docs/specs/adrs/ADR-0003-export-policy.md
+++ b/docs/specs/adrs/ADR-0003-export-policy.md
@@ -1,0 +1,26 @@
+# ADR-0003 — Export Policy (Security & Allowlist)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Define what data is included in exports to preserve provenance, protect sensitive data, and keep files compact.
+
+## Decision
+- Exports MUST include intake and results with stable IDs and provenance metadata (app version, ruleset hash, timestamps).
+- Exports MUST NOT include engine constants, pricing templates, or user secrets.
+- Export formats MUST be limited to: .sizewise (JSON or ZIP as per ADR-0005), PDF, CSV, DXF.
+
+## Consequences
+### Positive
+- Portable, verifiable files without leaking sensitive internals
+- Deterministic content facilitates diffing and audit
+
+### Negative
+- Some advanced consumers may want constants; they will rely on documented ruleset versions instead
+
+## Implementation Requirements
+- Enforce allowlist at exporter boundaries; validate against schema before writing
+- Add footers/headers with provenance; include exporter adapter version where applicable
+- Apply watermarking when in Grace Mode (see ADR-0008)
+

--- a/docs/specs/adrs/ADR-0004-canvas-scope-mvp.md
+++ b/docs/specs/adrs/ADR-0004-canvas-scope-mvp.md
@@ -1,0 +1,26 @@
+# ADR-0004 — Canvas Scope (MVP)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Constrain the MVP canvas feature set to guarantee determinism and delivery velocity.
+
+## Decision
+- Geometry MUST be orthogonal (0°/90°) with optional 45° via elbows only.
+- Supported fittings MUST include: elbow90, elbow45, tee, transition, endcap.
+- No freehand drawing, no arbitrary angles, no 3D, and no DXF import in MVP.
+
+## Consequences
+### Positive
+- Reduced edge cases; simpler hit testing and snapping
+- Easier to guarantee export determinism and performance
+
+### Negative
+- Limits flexibility for certain use cases (deferred to post-MVP)
+
+## Implementation Requirements
+- Snap grid and alignment rules; selection/merge/split/resize state machines
+- Deterministic block placement for fittings to match DXF adapter
+- Clear upgrade path documented for post-MVP features
+

--- a/docs/specs/adrs/ADR-0005-sizewise-packaging.md
+++ b/docs/specs/adrs/ADR-0005-sizewise-packaging.md
@@ -1,0 +1,37 @@
+# ADR-0005 — SizeWise Packaging (.sizewise JSON/ZIP)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Define a portable, integrity-checked project bundle format that is deterministic, diffable, and can optionally include assets.
+
+## Decision
+- The .sizewise format MUST default to a single JSON file (UTF-8) for diffability.
+- A ZIP container MAY be used only when embedding assets; manifest MUST be at /manifest.json.
+- MIME types MUST be:
+  - application/vnd.sizewise+json (JSON default)
+  - application/vnd.sizewise+zip (ZIP with assets)
+- Integrity MUST be SHA-256 over canonical JSON bytes.
+- Signing MAY use a detached signature (ed25519 or RSA). Import modes:
+  - Strict: signed only
+  - Standard: unsigned allowed with warning
+  - Labs: testing only
+
+## Consequences
+### Positive
+- Simple diffs and code reviews for most exports
+- Clear provenance with optional signatures
+- Asset support when required without constraining the default
+
+### Negative
+- Two profiles to support (JSON and ZIP)
+- Canonicalization rules must be strictly implemented to avoid false mismatches
+
+## Implementation Requirements
+- Canonical JSON writer and stable sort order of arrays
+- ZIP profile layout: /manifest.json and /assets/**
+- Enforce MIME types and OS association
+- Import policy flags (strict/standard/labs) are user/CI configurable
+- Password policy for encryption: min length 12; decrypt rate limiting
+

--- a/docs/specs/adrs/ADR-0006-dxf-profile-fonts.md
+++ b/docs/specs/adrs/ADR-0006-dxf-profile-fonts.md
@@ -1,0 +1,30 @@
+# ADR-0006 — DXF Profile & Fonts
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Lock a CAD-consumable DXF output that downstream tools will reliably render with correct layers, units, and text.
+
+## Decision
+- DXF version MUST be R2018; units MUST be inches (INSUNITS=1); UCS World.
+- Layers MUST follow the SizeWise layer map (DUCT_MAIN, FITTINGS, LABELS, NODES, GUIDES) with fixed color indices.
+- Text style MUST be SIZEWISE_STD with Arial; SHOULD fallback to SHX if Arial unavailable.
+- Text height SHOULD default to 0.125 in; configurable.
+- Blocks for fittings (ELBOW_90_LR, ELBOW_45, TEE, TRANSITION) MUST use consistent insertion points.
+- Adapter MUST support up to ~100k entities; writes MUST be chunked to avoid memory spikes.
+
+## Consequences
+### Positive
+- Predictable CAD import and plotting
+- Deterministic output across environments
+
+### Negative
+- Arial licensing and availability considerations
+- SHX fallback limits glyphs to ASCII subset
+
+## Implementation Requirements
+- Document layer/style map in docs/specs/49-dxf-layer-style-map.md
+- PDF/CSV exporters MUST include app version & ruleset hash; DXF MUST add header comments
+- Performance harness MUST exercise a 100k-entity export case
+

--- a/docs/specs/adrs/ADR-0007-update-provider.md
+++ b/docs/specs/adrs/ADR-0007-update-provider.md
@@ -1,0 +1,27 @@
+# ADR-0007 — Update Provider (GitHub Releases)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Select a hosted update provider for electron-updater with minimal operational overhead and strong security posture.
+
+## Decision
+- GitHub Releases MUST be used as the update provider for v1.
+- Beta and Stable channels MUST be supported; promotion from beta to stable occurs after smoke tests.
+- Rollback MUST be supported via allowDowngrade and channel pointer flip to prior stable tag.
+
+## Consequences
+### Positive
+- Low operational overhead; integrates with existing GitHub workflows
+- Built-in artifacts hosting and release notes
+
+### Negative
+- Private repository bandwidth limits may apply at scale
+- S3 or custom providers may be needed later for very large audiences
+
+## Implementation Requirements
+- electron-builder publish config points to GitHub Releases
+- CI uses OIDC/short-lived tokens; secrets not echoed
+- Release workflow includes notarize/staple and RFC3161 timestamp
+

--- a/docs/specs/adrs/ADR-0008-grace-mode-policy.md
+++ b/docs/specs/adrs/ADR-0008-grace-mode-policy.md
@@ -1,0 +1,27 @@
+# ADR-0008 — Grace Mode Policy
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Define application behavior when license verification fails or expires without abruptly blocking workflows.
+
+## Decision
+- Grace Mode MUST last 7 days by default.
+- Editing MUST be allowed during grace.
+- Exports MUST be watermarked (PDF/DXF/CSV) and batch exports MUST be disabled.
+- Cloud sync (if present) MUST be disabled while in grace.
+- An audit event SHOULD be recorded (lic_grace_entered) without PII.
+
+## Consequences
+### Positive
+- Users remain productive; encourages swift reactivation without data loss
+
+### Negative
+- Some workflows (batch exports/sync) are constrained during grace
+
+## Implementation Requirements
+- Watermark format defined and applied in exporters
+- UI banner with grace end date; link to re-activate
+- Event logged locally; included in support bundle
+

--- a/docs/specs/adrs/ADR-0009-labor-cost-enablement.md
+++ b/docs/specs/adrs/ADR-0009-labor-cost-enablement.md
@@ -1,0 +1,23 @@
+# ADR-0009 — Labor Cost Enablement (Placeholder)
+
+Status: Accepted
+Date: 2025-09-01
+
+## Problem
+Reserve decision record for enabling labor cost features post-MVP while keeping calculation engine insulated from pricing.
+
+## Decision
+- Costing features MUST remain out of MVP scope; calculation engine MUST output only technical metrics.
+- Pricing integration MAY be added post-MVP via separate module; outputs MUST remain deterministic and audit-friendly.
+
+## Consequences
+### Positive
+- Keeps MVP focused and auditable; avoids scope creep
+
+### Negative
+- Some users may expect costing earlier; set expectations via roadmap
+
+## Implementation Requirements
+- No cost fields in .sizewise schema v1
+- Clear UI boundaries; pricing module interacts only with exported summary data
+


### PR DESCRIPTION
This PR delivers the complete production-ready documentation suite aligned with the Notion specification, plus a full ADR set (ADR-0001..0009). Highlights:

- Documentation Index and full specs covering architecture, data formats, calculations, exporters, security, deployment, testing, ops, and licensing
- Exporters: Electron printToPDF primary; DXF R2018 conventions with layer/style map and Arial+SHX fallback; deterministic mappings
- File Format: .sizewise JSON default (ZIP for assets), MIME types, signing modes (Strict/Standard/Labs), password policy and decrypt rate limiting
- Security: telemetry defaults off/rotation; IPC hardening; import/signing policies; export encryption policies
- Error/Resilience: database corruption runbook, backups/retention, give-up thresholds; error catalog
- Testing: performance baseline & measurement protocol (P95), fuzz & invariants, QA inventory, performance harness
- Deployment: GitHub Releases provider, notarize/staple, RFC3161 timestamp, allowDowngrade rollback; CI/CD skeleton
- Licensing: Grace Mode (7 days) with export watermarking, sync/batch restrictions
- ADRs: 0001 Platform Stack; 0002 Canvas-First UI Model; 0003 Export Policy; 0004 Canvas Scope MVP; 0005 Packaging; 0006 DXF Profile/Fonts; 0007 Update Provider; 0008 Grace Mode Policy; 0009 Labor Cost Enablement

Scope is desktop-only (Windows/macOS/Linux), with mobile explicitly out-of-scope.

Once merged, this unblocks M0 implementation scaffolding and development.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author